### PR TITLE
Add an exception when evaluating an Additive Sharing Tensor in an if …

### DIFF
--- a/syft/frameworks/torch/tensors/interpreters/additive_shared.py
+++ b/syft/frameworks/torch/tensors/interpreters/additive_shared.py
@@ -74,6 +74,12 @@ class AdditiveSharingTensor(AbstractTensor):
             out += "\n\t*crypto provider: {}*".format(self.crypto_provider.id)
         return out
 
+    def __bool__(self):
+        """Prevent evaluation of encrypted tensor"""
+        raise ValueError(
+            "Additive shared tensors can't be converted boolean values. You should decrypt it first."
+        )
+
     @property
     def locations(self):
         """Provide a locations attribute"""

--- a/test/torch/tensors/test_additive_shared.py
+++ b/test/torch/tensors/test_additive_shared.py
@@ -21,7 +21,7 @@ def test_wrap(workers):
     assert isinstance(x.child.child, torch.Tensor)
 
 
-def test__str__(workers):
+def test___str__(workers):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
     x_sh = torch.tensor([[3, 4]]).share(alice, bob, crypto_provider=james)
     assert isinstance(x_sh.__str__(), str)
@@ -35,6 +35,15 @@ def test_share_get(workers):
     x = x.get()
 
     assert (x == t).all()
+
+
+def test___bool__(workers):
+    bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
+    x_sh = torch.tensor([[3, 4]]).share(alice, bob, crypto_provider=james)
+
+    with pytest.raises(ValueError):
+        if x_sh:  # pragma: no cover
+            pass
 
 
 def test_share_inplace_consistency(workers):


### PR DESCRIPTION
…statement (#2874)

* Add an exception when evaluation an AST as a bool

* Clean test using pytest syntax

Co-authored-by: George-Cristian Muraru <george.muraru@stud.acs.upb.ro>
Co-authored-by: Karl Higley <kmhigley@gmail.com>